### PR TITLE
Fix README pipeline YAML references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ kubectl create secret docker-registry quay-credentials \
 
 ## 📝 2. Tekton Pipeline YAML
 
-Save the following as `buildah-quay-pipeline.yaml`:
+Save the following as `quay-new-buildah-hello-pipeline.yaml`:
 
 ```yaml
 apiVersion: tekton.dev/v1
@@ -116,7 +116,7 @@ spec:
 Apply the pipeline YAML:
 
 ```bash
-kubectl apply -f buildah-quay-pipeline.yaml
+kubectl apply -f quay-new-buildah-hello-pipeline.yaml
 ```
 
 Check the logs:


### PR DESCRIPTION
## Summary
- update pipeline file name to `quay-new-buildah-hello-pipeline.yaml`
- adjust `kubectl apply` example to use the same file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b2cd5513c832ca4df9c31b3dc5812