### PR TITLE
Add YAML lint workflow

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,19 @@
+name: YAML Lint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install yamllint
+        run: pip install yamllint
+      - name: Run yamllint
+        run: yamllint $(git ls-files '*.yaml')


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint YAML files

## Testing
- `yamllint $(git ls-files '*.yaml')` *(fails: too many lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_684b2d9212e4832c9dcc487493ab666b